### PR TITLE
Fixed assignment to undeclared variable "vCallback"

### DIFF
--- a/scripts/PickPocketManager.js
+++ b/scripts/PickPocketManager.js
@@ -97,7 +97,7 @@ class PickPocketManager {
 					PickPocketManager.RequestPickPocket(vData);
 				}
 				else {	
-					vCallback = async (psuccessdegree) => {
+					let vCallback = async (psuccessdegree) => {
 						let vData = {SceneID : pTarget.parent.id, TargetID : pTarget.id, CharacterID : pCharacter.id, useSystemRoll : true, Systemresult : psuccessdegree};
 						
 						PickPocketManager.RequestPickPocket(vData);


### PR DESCRIPTION
In Firefox got an error stating vCallback was an undeclared variable. Pickpocketing did not work as a result. Fixed it for me 🤷